### PR TITLE
Make the async event loop reusable.

### DIFF
--- a/app/python_apps/aiohttp_ratelimit.py
+++ b/app/python_apps/aiohttp_ratelimit.py
@@ -95,6 +95,8 @@ class AsyncApi(AsyncLooper):
         self.limiter = AsyncioBucketTimeRateLimiter(max_size=max_size, recovery_time=recovery_time, rest_time=rest_time)
         self.limiter.activate()
 
+    def __del__(self):
+        self.limiter.deactivate()
 
     @property
     def get_data(self):

--- a/app/python_apps/aiohttp_ratelimit.py
+++ b/app/python_apps/aiohttp_ratelimit.py
@@ -93,10 +93,6 @@ class AsyncApi(AsyncLooper):
         # self._loop = self.looper.loop
         super().__init__()
         self.limiter = AsyncioBucketTimeRateLimiter(max_size=max_size, recovery_time=recovery_time, rest_time=rest_time)
-        self.limiter.activate()
-
-    def __del__(self):
-        self.limiter.deactivate()
 
     @property
     def get_data(self):

--- a/app/python_apps/aiohttp_ratelimit.py
+++ b/app/python_apps/aiohttp_ratelimit.py
@@ -82,11 +82,10 @@ class AsyncLooper:
 
 
 class AsyncApi:
+    _loop = AsyncLooper().loop
 
     def __init__(self, max_size=10, recovery_time=5.0, rest_time=0.5):
-        self.looper = AsyncLooper()
-        self._loop = self.looper.loop
-        events.set_event_loop(self.loop)
+        # self._loop = self.looper.loop
         self.limiter = AsyncioBucketTimeRateLimiter(max_size=max_size, recovery_time=recovery_time, rest_time=rest_time)
         self.limiter.activate()
 


### PR DESCRIPTION
You can only use an event loop in each thread.
So this modification makes the API reusable.
Also, use `atexit` to ensure the exit process will be executed. 
